### PR TITLE
fix button not working on firefox

### DIFF
--- a/web/views/client/add.html
+++ b/web/views/client/add.html
@@ -119,7 +119,7 @@
                     <div class="hr-line-dashed"></div>
                     <div class="form-group">
                         <div class="col-sm-4 col-sm-offset-2">
-                            <button class="btn btn-success" href="#" id="add"><i
+                            <button class="btn btn-success" type="button" id="add"><i
                                     class="fa fa-fw fa-lg fa-eye"></i>新增
                             </button>
                         </div>

--- a/web/views/client/edit.html
+++ b/web/views/client/edit.html
@@ -128,7 +128,7 @@
                     <div class="hr-line-dashed"></div>
                     <div class="form-group">
                         <div class="col-sm-4 col-sm-offset-2">
-                            <button class="btn btn-success" href="#" id="add"><i
+                            <button class="btn btn-success" type="button" id="add"><i
                                     class="fa fa-fw fa-lg fa-eye"></i><span langtag="info-save">保存</span>
                             </button>
                         </div>

--- a/web/views/index/add.html
+++ b/web/views/index/add.html
@@ -101,7 +101,7 @@
                     <div class="hr-line-dashed"></div>
                     <div class="form-group">
                         <div class="col-sm-4 col-sm-offset-2">
-                            &nbsp;<button class="btn btn-success" href="#" id="add"><i
+                            &nbsp;<button class="btn btn-success" type="button" id="add"><i
                                 class="fa fa-fw fa-lg fa-eye"></i>新增
                         </button>
                         </div>

--- a/web/views/index/edit.html
+++ b/web/views/index/edit.html
@@ -101,7 +101,7 @@
                     <div class="hr-line-dashed"></div>
                     <div class="form-group">
                         <div class="col-sm-4 col-sm-offset-2">
-                            <button class="btn btn-success" href="#" id="add"><i
+                            <button class="btn btn-success" type="button" id="add"><i
                                     class="fa fa-fw fa-lg fa-eye"></i><span langtag="info-save">保存</span>
                             </button>
                         </div>

--- a/web/views/index/hadd.html
+++ b/web/views/index/hadd.html
@@ -97,7 +97,7 @@
                     <div class="hr-line-dashed"></div>
                     <div class="form-group">
                         <div class="col-sm-4 col-sm-offset-2">
-                            &nbsp;<button class="btn btn-success" href="#" id="add"><i
+                            &nbsp;<button class="btn btn-success" type="button" id="add"><i
                                 class="fa fa-fw fa-lg fa-eye"></i>新增
                         </button>
                         </div>

--- a/web/views/index/hedit.html
+++ b/web/views/index/hedit.html
@@ -100,7 +100,7 @@
                     <div class="hr-line-dashed"></div>
                     <div class="form-group">
                         <div class="col-sm-4 col-sm-offset-2">
-                            &nbsp;<button class="btn btn-success" href="#" id="add"><i
+                            &nbsp;<button class="btn btn-success" type="button" id="add"><i
                                 class="fa fa-fw fa-lg fa-eye"></i><span langtag="info-save">保存</span>
                         </button>
                         </div>


### PR DESCRIPTION
> 修复firefox下新增按钮不可用

根据w3c标准，form表单下的button的属性type缺省值是"submit"，导致点击新增时会提交当前表单刷新页面。个人分析由于页面刷新导致异步的ajax没有完整就被中断掉了。

> 解决方式就是显性的指定button类型为button